### PR TITLE
tweaked cli args

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **RBE3002-tb3-setup**
+# **TurtleBoot**
 Bash scripts to auto install ROS (Jazzy) on a Turtlebot3 at various points of the setup process.
 ```
  _____           _   _      ____              _   
@@ -19,6 +19,11 @@ That depends on what status your microSD card is in!
 ## Turtleboot Lite:
 Script name: `turtleboot_lite.bash`
 
+### Args:
+`-h | --help`: Shows information on all args/flags</br>
+`-n | --name NAME`: Sets the hostname of the turtlebot (default is turtle_boot)</br>
+`-id | --ros-id ID`: Sets the ROS_DOMAIN_ID environment variable
+
 ### Features:
 - Regenerates ssh keys
 - Changes the hostname
@@ -34,8 +39,8 @@ I want to change my hostname to "hello-there", my `ROS_DOMAIN_ID` to 22 and I do
 
 First make the script executable with:
 </br>
-`chmod +x scriptname.bash`
+`chmod +x turtleboot_lite.bash`
 
 Run the script:
 </br>
-`sudo ./turtleboot.bash "hello-there" "22" false`
+`sudo bash turtleboot_lite.bash`

--- a/turtleboot_lite.bash
+++ b/turtleboot_lite.bash
@@ -1,16 +1,19 @@
 #!/bin/bash
 
+# Turtleboot Lite v1.0.2
 # Reconfiguring the network settings / regenerating SSH Key only after a microSD clone
-# Status --> UNTESTED
+# Status --> TESTED (On Ubuntu 24.04 VM)
 
 # exit on errors
 set -e
 
-# variables from cl args
-TURTLEBOT_NAME="turtlebot3-clone"
+# variables from cl args with defaults
+TURTLEBOT_NAME="turtle_boot"
 ROS_ID="30"
 REBUILD="false"
+REBOOT="false"
 
+# handling cli args
 while [[ $# -gt 0 ]]; do
     case $1 in
         --name|-n)
@@ -25,12 +28,12 @@ while [[ $# -gt 0 ]]; do
             REBUILD="true"
             shift
             ;;
-        --no-rebuild)
-            REBUILD="false"
+        --reboot)
+            REBOOT="true"
             shift
             ;;
         --help|-h)
-            echo "Usage: $0 [--name|-n NAME] [--ros-id|-id ID] [--rebuild|--no-rebuild]"
+            echo "Usage: $0 [--name|-n NAME] [--ros-id|-id ID] [--rebuild| None] [--reboot| None]"
             exit 0
             ;;
         *)
@@ -40,6 +43,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# fun ascii art :)
 cat << "EOF"
  _____           _   _      ____              _   
 |_   _|   _ _ __| |_| | ___| __ )  ___   ___ | |_ 
@@ -80,16 +84,26 @@ hostnamectl set-hostname $TURTLEBOT_NAME
 sed -i "2s/.*/127.0.0.1 $TURTLEBOT_NAME/" /etc/hosts
 echo "hostname set to $TURTLEBOT_NAME !"
 
-# cd into turtlebot3_ws
-cd ~/turtlebot3_ws/
+# rebuild tb3 packages set with flag --rebuild
+if [ "$REBUILD" = true ]; then
+    # cd into turtlebot3_ws
+    cd ~/turtlebot3_ws/
 
-# rebuild tb3 packages?
-if [ -d ~/turtlebot3_ws ]; then
-    cd ~/turtlebot3_ws
-    if [ "$REBUILD" = true ]; then
+    # confirm the correct directory
+    if [ -d ~/turtlebot3_ws ]; then
+        # rebuild turtlebot3_ws
         colcon build --symlink-install 
     fi
 fi
 
+# confirm reconfig status
 echo "Reconfiguration Finished!"
+
+# made rebooting after setup optional, REBOOT is set with the --reboot flag
+if ["$REBOOT" = true ]; then
+    reboot
+fi
+
+# warning if --reboot was not chosen in cli args
+echo "Please reboot in order to see Turtleboot Lite's changes take effect!"
 exit 0


### PR DESCRIPTION
This pull request updates the `README.md` and `turtleboot_lite.bash` script to improve usability and functionality for setting up Turtlebot3. Key changes include renaming the project, adding new CLI arguments, refining script behavior, and enhancing documentation.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Renamed the project from `RBE3002-tb3-setup` to `TurtleBoot` and updated instructions to reflect the new script name (`turtleboot_lite.bash`). Added descriptions for new CLI arguments (`--help`, `--name`, `--ros-id`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22-R26) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R46)

### Script enhancements:
* [`turtleboot_lite.bash`](diffhunk://#diff-fee98ba0c1303d0ffc612ffd367ce523135a1b46fdc3688570acb35f7ebb55f0R3-R16): Updated script status from "UNTESTED" to "TESTED" and added versioning information (`v1.0.2`). Introduced new default values for variables and added a `--reboot` flag to optionally reboot after setup. Improved CLI argument handling and added ASCII art for visual appeal. [[1]](diffhunk://#diff-fee98ba0c1303d0ffc612ffd367ce523135a1b46fdc3688570acb35f7ebb55f0R3-R16) [[2]](diffhunk://#diff-fee98ba0c1303d0ffc612ffd367ce523135a1b46fdc3688570acb35f7ebb55f0L28-R36) [[3]](diffhunk://#diff-fee98ba0c1303d0ffc612ffd367ce523135a1b46fdc3688570acb35f7ebb55f0R46)
* [`turtleboot_lite.bash`](diffhunk://#diff-fee98ba0c1303d0ffc612ffd367ce523135a1b46fdc3688570acb35f7ebb55f0R87-R108): Made package rebuilding conditional based on the `--rebuild` flag and added logic to handle optional rebooting with the `--reboot` flag. Included warnings if a reboot is not chosen.