### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # **TurtleBoot**
-Bash scripts to auto install ROS (Jazzy) on a Turtlebot3 at various points of the setup process.
+Bash scripts to auto install ROS (Jazzy) and configure the SBC on a Turtlebot3. 
 ```
  _____           _   _      ____              _   
 |_   _|   _ _ __| |_| | ___| __ )  ___   ___ | |_ 
@@ -12,7 +12,6 @@ Bash scripts to auto install ROS (Jazzy) on a Turtlebot3 at various points of th
                 |_________/     
                 |_|_| |_|_|
 ```
-
 ## Turtleboot Lite:
 Script name: `turtleboot_lite.bash`
 
@@ -41,4 +40,4 @@ First make the script executable with:
 
 Run the script:
 </br>
-`sudo bash turtleboot_lite.bash --name shelly --ros-id 22 --reboot`
+`bash turtleboot_lite.bash --name shelly --ros-id 22 --reboot`


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to clarify functionality and improve instructions for running the `turtleboot_lite.bash` script.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R2): Updated the description to specify that the Bash scripts also configure the SBC on a Turtlebot3, in addition to installing ROS (Jazzy).
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15): Removed unnecessary whitespace in the Turtleboot Lite section.

Instruction improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R43): Updated the command for running the `turtleboot_lite.bash` script, removing the unnecessary `sudo` prefix for better clarity and alignment with best practices.